### PR TITLE
Fix RecordLengthError to output correct values

### DIFF
--- a/lib/flat/read_operations.rb
+++ b/lib/flat/read_operations.rb
@@ -33,7 +33,7 @@ module ReadOperations
         next if line.length.zero?
 
         unless (self.width - line.length).zero?
-          raise Errors::RecordLengthError, "length is #{line.length} but should be #{self.width}"
+          raise Errors::RecordLengthError, "length is #{self.width} but should be #{line.length}"
         end
 
         yield create_record(line, io.lineno), line


### PR DESCRIPTION
Simply swapping the values in the error message for them to display in the correct order.