### PR TITLE
Update field.rb

### DIFF
--- a/lib/flat/field.rb
+++ b/lib/flat/field.rb
@@ -126,7 +126,7 @@ module Field
     # String#pack, String#unpack
     #
     def pack_format
-      "A#{width}"
+      "a#{width}"
     end
 
     ##


### PR DESCRIPTION
In a legacy flat file the length of the fields must remain consistent and should not be trimmed. 
If necessary, you can use a trim filter to remove spaces for a specific field.